### PR TITLE
Katello-jobs for dynflow integration needs to be running before seed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,8 +37,8 @@ class katello (
   class { 'katello::install': } ~>
   class { 'certs::katello': } ~>
   class { 'katello::config': } ~>
-  Exec['foreman-rake-db:seed'] ~>
-  class{ 'katello::service': }
+  class { 'katello::service': } ~>
+  Exec['foreman-rake-db:seed']
 
   class { '::certs::pulp_parent': } ~>
   class { 'pulp':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,8 @@ class katello::service {
 
   service {'katello-jobs':
     ensure      => running,
+    require     => Exec['foreman-rake-db:migrate'],
+    before      => Service[httpd],
     enable      => true,
     hasstatus   => true,
     hasrestart  => true,


### PR DESCRIPTION
The executor needs to be ready before processing Dynflow execution plans, that
might occur as part of the seed process.
