### PR TITLE
Adding ability to configure whether passenger is being used to make

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@
 #
 # $config_dir::         Location for Katello config files
 #
+# $use_passenger::      Whether Katello is being deployed with Passenger;
+#                       default true
+#
 class katello (
 
   $user = $katello::params::user,
@@ -37,7 +40,9 @@ class katello (
   $post_sync_token = $katello::params::post_sync_token,
 
   $log_dir = $katello::params::log_dir,
-  $config_dir = $katello::params::config_dir
+  $config_dir = $katello::params::config_dir,
+
+  $use_passenger = $katello::params::use_passenger
 
   ) inherits katello::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class katello::params {
   $oauth_secret = cache_data($oauth_token_file, random_password(32))
 
   $post_sync_token_file = '/etc/katello/post_sync_token'
-  $post_sync_token = find_or_create_password($post_sync_token_file)
+  $post_sync_token = cache_data('post_sync_token', random_password(32))
 
   # Subsystems settings
   $candlepin_url = 'https://localhost:8443/candlepin'
@@ -71,4 +71,6 @@ class katello::params {
   $use_foreman = false
   $ldap_roles = false
   $validate_ldap = false
+
+  $use_passenger = true
 }

--- a/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
+++ b/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
@@ -7,7 +7,9 @@ SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
 
 Alias /pub /var/www/html/pub
 <Location /pub>
-  PassengerEnabled off 
+  <% if @use_passenger %>
+  PassengerEnabled off
+  <% end %>
   Options +FollowSymLinks +Indexes
 </Location>
 

--- a/templates/katello.yml.erb
+++ b/templates/katello.yml.erb
@@ -29,13 +29,13 @@ common:
 
   candlepin:
     url: <%= scope.lookupvar("katello::params::candlepin_url") %>
-    oauth_key: <%= scope.lookupvar("katello::params::oauth_key") %>
-    oauth_secret: <%= scope.lookupvar("katello::params::oauth_secret") %>
+    oauth_key: <%= @oauth_key %>
+    oauth_secret: <%= @oauth_secret %>
 
   pulp:
     url: <%= scope.lookupvar("katello::params::pulp_url") %>
-    oauth_key: <%= scope.lookupvar("katello::params::oauth_key") %>
-    oauth_secret: <%= scope.lookupvar("katello::params::oauth_secret") %>
+    oauth_key: <%= @oauth_key %>
+    oauth_secret: <%= @oauth_secret %>
 
   foreman:
     url: <%= scope.lookupvar("katello::params::foreman_url") %>


### PR DESCRIPTION
the Katello vhost configuration re-usable by non-passenger deployments.
Includes generalization of oauth_secret and oauth_key to support deployment
of katello.yml by other modules.
