### PR TITLE
fixes #5486  prefix and candlepin url incorrect for rhsm template on dev...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,9 @@ class katello (
 
   Class['certs'] ~>
   class { 'certs::apache': } ~>
-  class { 'certs::katello': } ~>
+  class { 'certs::katello':
+    deployment_url => $katello::deployment_url,
+  } ~>
   class { 'katello::install': } ~>
   class { 'katello::config': } ~>
   class { 'certs::candlepin': } ~>


### PR DESCRIPTION
... install

Depends on https://github.com/Katello/puppet-certs/pull/13
- bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1092474
- certs::katello requires the param deployment_url
