### PR TITLE
Fixes #6544 - creates qpid config items in k conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,8 @@ class katello (
   class { 'katello::install': } ~>
   class { 'katello::config': } ~>
   class { 'certs::qpid': } ~>
+  class { 'qpid::client': } ~>
+  class { 'katello::qpid': } ~>
   class { 'certs::candlepin': } ~>
   class { 'candlepin':
     user_groups       => $katello::user_groups,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,4 +71,6 @@ class katello::params {
   $validate_ldap = false
 
   $use_passenger = true
+
+  $candlepin_event_queue = 'katello_event_queue'
 }

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,0 +1,19 @@
+# Katello Config
+class katello::qpid (
+  $client_cert            = "${certs::qpid::client_cert}",
+  $client_key             = "${certs::qpid::client_key}"
+){
+  exec { 'create katello entitlments queue':
+    command => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' add queue ${::katello::params::candlepin_event_queue} --durable",
+    unless  => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${::katello::params::candlepin_event_queue}",
+    path => "/usr/bin",
+    logoutput => true
+  }
+  exec { 'bind katello entitlments queue to qpid exchange messages that deal with entitlements':
+    command => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' bind event ${katello::params::candlepin_event_queue} '*.*'",
+    onlyif => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${::katello::params::candlepin_event_queue}",
+    path => "/usr/bin",
+    logoutput => true
+  }
+
+}

--- a/templates/katello.yml.erb
+++ b/templates/katello.yml.erb
@@ -48,6 +48,10 @@ common:
     oauth_key: <%= scope.lookupvar("katello::params::oauth_key") %>
     oauth_secret: <%= scope.lookupvar("katello::params::oauth_secret") %>
 
+  qpid:
+    url: 'amqp:ssl:<%= scope.lookupvar("::fqdn") %>:5671'
+    subscriptions_queue_address: <%= scope.lookupvar("katello::params::candlepin_event_queue") %>
+
 <%- if @proxy_url -%>
   cdn_proxy:
     host: <%= @proxy_url %>


### PR DESCRIPTION
Creates qpid configuration items in katello.yml. Specifically, it
sets information about the amqp url and the name of the entitlement
queue.
