### PR TITLE
Fixes #6544 - q to receive candlepin events

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,6 @@ PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send("disable_class_inherits_from_params_class")
 PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send('disable_autoloader_layout')
 
 task :default => [:lint]

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,10 +2,10 @@
 class katello::config {
 
   file { '/usr/share/foreman/bundler.d/katello.rb':
-    ensure  => file,
-    owner   => $katello::user,
-    group   => $katello::group,
-    mode    => '0644',
+    ensure => file,
+    owner  => $katello::user,
+    group  => $katello::group,
+    mode   => '0644',
   }
 
   file { "${katello::config_dir}/katello.yaml":
@@ -30,10 +30,10 @@ class katello::config {
   }
 
   file { "${katello::config_dir}/katello":
-    ensure  => directory,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
   }
 
   file { "${katello::config_dir}/katello/client.conf":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,11 @@ class katello (
     proxy_username              => $proxy_username,
     proxy_password              => $proxy_password,
   } ~>
+  class { 'qpid::client': } ~>
+  class { 'katello::qpid':
+    client_cert => $certs::qpid::client_cert,
+    client_key  => $certs::qpid::client_key,
+  } ~>
   class{ 'elasticsearch': } ~>
   Exec['foreman-rake-db:seed']
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,4 +61,7 @@ class katello::params {
   $validate_ldap = false
 
   $use_passenger = true
+
+  $qpid_url = "amqp:ssl:${::fqdn}:5671"
+  $candlepin_event_queue = 'katello_event_queue'
 }

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,0 +1,23 @@
+# Katello Config
+class katello::qpid (
+  $client_cert            = undef,
+  $client_key             = undef,
+){
+
+  User<|title == $katello::user|>{groups +> $certs::qpidd_group}
+  exec { 'create katello entitlments queue':
+    command   => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' add queue ${katello::params::candlepin_event_queue} --durable",
+    unless    => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${katello::params::candlepin_event_queue}",
+    path      => '/usr/bin',
+    require   => Service['qpidd'],
+    logoutput => true,
+  }
+  exec { 'bind katello entitlments queue to qpid exchange messages that deal with entitlements':
+    command   => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' bind event ${katello::params::candlepin_event_queue} '*.*'",
+    onlyif    => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${katello::params::candlepin_event_queue}",
+    path      => '/usr/bin',
+    require   => Service['qpidd'],
+    logoutput => true,
+  }
+
+}

--- a/templates/katello.yml.erb
+++ b/templates/katello.yml.erb
@@ -46,6 +46,10 @@ common:
     oauth_key: <%= scope.lookupvar("katello::params::oauth_key") %>
     oauth_secret: <%= scope.lookupvar("katello::params::oauth_secret") %>
 
+  qpid:
+    url: <%= @qpid_url %>
+    subscriptions_queue_address: <%= @candlepin_event_queue %>
+
 <%- if @proxy_url -%>
   cdn_proxy:
     host: <%= @proxy_url %>


### PR DESCRIPTION
This creates a queue so that katello can receive candlepin events.
It also sets config items for the queue's url and address in katello.yml so katello can
connect to the queue.
