### PR TITLE
Refs #6806: Remove references to passencrypt.

### DIFF
--- a/templates/katello.yml.erb
+++ b/templates/katello.yml.erb
@@ -76,16 +76,3 @@ common:
     <%- end -%>
     provider_url: https://<%= scope.lookupvar('fqdn') -%>/signo
     logout_path: /logout
-
-  database:
-    username:
-    password:
-
-<%# bug #7991 in puppet 2.6 - need to explicitly load custom functions %>
-<% Puppet::Parser::Functions::function('katello_passencrypt') %>
-
-production:
-  database:
-    username: <%= scope.lookupvar("katello::params::db_user") %>
-    password: <%= scope.function_katello_passencrypt([scope.lookupvar("katello::params::db_pass")]) %>
-    database: <%= scope.lookupvar("katello::params::db_name") %>


### PR DESCRIPTION
Note this also removes the database configs which are now provided
by the Foreman core app.
