### PR TITLE
refs #7779 - Updating to add support for pulp crane

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,6 +12,7 @@ fixtures:
     qpid:          "git://github.com/katello/puppet-qpid.git"
     candlepin:     "git://github.com/katello/puppet-candlepin.git"
     pulp:          "git://github.com/katello/puppet-pulp.git"
+    crane:          "git://github.com/katello/puppet-crane.git"
     elasticsearch: "git://github.com/katello/puppet-elasticsearch.git"
   symlinks:
     katello: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,11 @@ class katello (
     proxy_username              => $proxy_username,
     proxy_password              => $proxy_password,
   } ~>
+  class { 'crane':
+    cert    => $certs::apache::apache_cert,
+    key     => $certs::apache::apache_key,
+    ca_cert => $certs::ca_cert,
+  } ~>
   class { 'qpid::client': } ~>
   class { 'katello::qpid':
     client_cert  => $certs::qpid::client_cert,

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,10 @@
        "version_requirement": ">= 0.1.0"
     },
     {
+       "name": "katello-crane",
+       "version_requirement": ">= 0.1.0"
+    },
+    {
        "name": "katello-elasticsearch",
        "version_requirement": ">= 0.1.0"
     },


### PR DESCRIPTION
This PR is one of a collection of PRs to puppet modules which will be needed to enable katello to support install/config of pulp docker & crane on the katello server.

The related PRs, so far are:
- this one
- https://github.com/Katello/puppet-pulp/pull/29
- https://github.com/Katello/puppet-crane/pull/1
