### PR TITLE
Fixes #7802 - ensures qpidd group present before adding user to group

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -2,12 +2,13 @@
 class katello::qpid (
   $client_cert            = undef,
   $client_key             = undef,
-  $katello_user           = undef
+  $katello_user           = $katello::user
 ){
   if $katello_user == undef {
     fail('katello_user not defined')
   } else {
-    User<|title == $katello_user|>{groups +> $certs::qpidd_group}
+    Group['qpidd'] ->
+    User<|title == $katello_user|>{groups +> 'qpidd'}
   }
   exec { 'create katello entitlments queue':
     command   => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' add queue ${katello::params::candlepin_event_queue} --durable",

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -1,8 +1,10 @@
 require 'spec_helper'
 
 describe 'katello' do
-
  context 'on redhat' do
+   let(:params) do
+     {:user => 'foreman'}
+   end
     let :facts do
       {
         :concat_basedir             => '/tmp',


### PR DESCRIPTION
Related pull-requests that fixes  #7802
https://github.com/Katello/puppet-katello/pull/45
https://github.com/Katello/puppet-katello_devel/pull/26
https://github.com/Katello/puppet-qpid/pull/11
