### PR TITLE
Fixes #8444 - Expose cdn_ssl_version as an installer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@
 #
 # $proxy_password::     Proxy password for authentication
 #
+# $cdn_ssl_version::    SSL version used to communicate with the CDN. Optional. Use SSLv23 or TLSv1
+#
 class katello (
 
   $user = $katello::params::user,
@@ -51,6 +53,7 @@ class katello (
   $proxy_port     = $katello::params::proxy_port,
   $proxy_username = $katello::params::proxy_username,
   $proxy_password = $katello::params::proxy_password,
+  $cdn_ssl_version = $katello::params::cdn_ssl_version,
 
   ) inherits katello::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,9 @@ class katello::params {
   $proxy_username = undef
   $proxy_password = undef
 
+  # cdn ssl settings
+  $cdn_ssl_version = undef
+
   # system settings
   $user = 'foreman'
   $group = 'foreman'

--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe 'katello::config' do
+  let :facts do
+    {
+      :concat_basedir => '/tmp',
+      :interfaces     => '',
+      :osfamily               => 'RedHat',
+      :operatingsystem        => 'CentOS',
+      :operatingsystemrelease => '6.5',
+    }
+  end
+
+  context 'default config settings' do
+    let(:pre_condition) do
+       ['include foreman','include certs']
+    end
+
+    it 'should NOT set the cdn-ssl-version' do
+      should_not contain_file('/etc/foreman/plugins/katello.yaml').
+        with_content(/cdn_ssl_version/)
+    end
+  end
+end

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -19,6 +19,19 @@ describe 'katello' do
     it { should contain_class('katello::install') }
     it { should contain_class('katello::config') }
     it { should contain_class('katello::service') }
+
+    context 'on setting cdn-ssl-version' do
+      let :params do
+        {
+          "cdn_ssl_version" => 'TLSv1'
+        }
+      end
+
+      it 'should set up the cdn_ssl_version' do
+        should contain_file('/etc/foreman/plugins/katello.yaml').
+          with_content(/^\s*cdn_ssl_version:\s*TLSv1$/)
+      end
+    end
   end
 
   context 'on centos' do

--- a/templates/katello.yml.erb
+++ b/templates/katello.yml.erb
@@ -13,6 +13,9 @@
 
 common:
   app_mode: 'katello'
+  <%- if @cdn_ssl_version && !@cdn_ssl_version.strip.empty?-%>
+  cdn_ssl_version: <%= @cdn_ssl_version %>
+  <%- end -%>
 
   warden:  <%= scope.lookupvar("katello::params::auth_method") %>
   ldap_roles: <%= scope.lookupvar("katello::params::ldap_roles") %>


### PR DESCRIPTION
$ katello-installer --help | grep cdn-ssl

  --katello-cdn-ssl-version     SSL version used to communicate with the
CDN. Optional. Use SSLv23 or TLSv1 (default: nil)

$ katello-installer  --katello-cdn-ssl-version=TLSv1
will add the following to /etc/foreman/plugins/katello.yaml

common:
  cdn_ssl_version: TLSv1
