### PR TITLE
refs #9060 - configure qpid::client with params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,12 @@ class katello (
     key     => $certs::apache::apache_key,
     ca_cert => $certs::ca_cert,
   } ~>
-  class { 'qpid::client': } ~>
+  class { 'qpid::client':
+    ssl                    => true,
+    ssl_cert_name          => 'broker',
+    ssl_cert_db            => $certs::nss_db_dir,
+    ssl_cert_password_file => $certs::qpid::nss_db_password_file,
+  } ~>
   class { 'katello::qpid':
     client_cert  => $certs::qpid::client_cert,
     client_key   => $certs::qpid::client_key,

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -20,6 +20,12 @@ describe 'katello' do
     it { should contain_class('katello::config') }
     it { should contain_class('katello::service') }
 
+    it "should configure a qpid client" do
+      should contain_class('qpid::client').
+        with(:ssl             => true,
+             :ssl_cert_name   => 'broker')
+    end
+
     context 'on setting cdn-ssl-version' do
       let :params do
         {


### PR DESCRIPTION
Add parameters for configuring the client, needed for the changes that happened in https://github.com/Katello/puppet-qpid/pull/12