### PR TITLE
refs #11737 - connect to localhost for qpid

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,18 +103,19 @@ class katello (
     ssl_cert_db            => $::certs::nss_db_dir,
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     ssl_cert_name          => 'broker',
+    interface              => 'lo',
   } ~>
   class { '::certs::qpid_client': } ~>
   class { '::pulp':
     oauth_enabled          => true,
     oauth_key              => $katello::oauth_key,
     oauth_secret           => $katello::oauth_secret,
-    messaging_url          => "ssl://${::fqdn}:5671",
+    messaging_url          => 'ssl://localhost:5671',
     messaging_ca_cert      => $::certs::ca_cert,
     messaging_client_cert  => $certs::qpid_client::messaging_client_cert,
     messaging_transport    => 'qpid',
     messaging_auth_enabled => false,
-    broker_url             => "qpid://${::fqdn}:5671",
+    broker_url             => 'qpid://localhost:5671',
     broker_use_ssl         => true,
     consumers_crl          => $candlepin::crl_file,
     proxy_url              => $proxy_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class katello::params {
   # database reinitialization flag
   $reset_data = 'NONE'
 
-  $qpid_url = "amqp:ssl:${::fqdn}:5671"
+  $qpid_url = 'amqp:ssl:localhost:5671'
   $candlepin_event_queue = 'katello_event_queue'
   $enable_ostree = false
   $max_keep_alive = 10000

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -12,15 +12,15 @@ class katello::qpid (
     User<|title == $katello_user|>{groups +> 'qpidd'}
   }
   exec { 'create katello entitlements queue':
-    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' add queue ${candlepin_event_queue} --durable",
-    unless    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' queues ${candlepin_event_queue}",
+    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' add queue ${candlepin_event_queue} --durable",
+    unless    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' queues ${candlepin_event_queue}",
     path      => '/usr/bin',
     require   => Service['qpidd'],
     logoutput => true,
   } ~>
   exec { 'bind katello entitlements queue to qpid exchange messages that deal with entitlements':
-    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' bind event ${candlepin_event_queue} '*.*'",
-    onlyif    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' queues ${candlepin_event_queue}",
+    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' bind event ${candlepin_event_queue} '*.*'",
+    onlyif    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://localhost:5671' queues ${candlepin_event_queue}",
     path      => '/usr/bin',
     require   => Service['qpidd'],
     logoutput => true,

--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -37,7 +37,7 @@ describe 'katello::config' do
           '    :oauth_key: katello',
           '    :oauth_secret: secret',
           '  :qpid:',
-          "    :url: amqp:ssl:#{facts[:fqdn]}:5671",
+          "    :url: amqp:ssl:localhost:5671",
           '    :subscriptions_queue_address: katello_event_queue'
         ]
       end
@@ -75,7 +75,7 @@ describe 'katello::config' do
           '    :oauth_key: katello',
           '    :oauth_secret: secret',
           '  :qpid:',
-          "    :url: amqp:ssl:#{facts[:fqdn]}:5671",
+          "    :url: amqp:ssl:localhost:5671",
           '    :subscriptions_queue_address: katello_event_queue',
           '  :cdn_proxy:',
           '    :host: http://myproxy.org',


### PR DESCRIPTION
Required PR's
- [ ] https://github.com/Katello/katello-installer/pull/260 (installer migration)
- [ ] puppet-katello (this one)
- [ ] https://github.com/Katello/puppet-katello_devel/pull/67
- [ ] https://github.com/Katello/puppet-capsule/pull/96
- [ ] https://github.com/Katello/puppet-certs/pull/65
- [ ] https://github.com/Katello/puppet-candlepin/pull/44

Test with:

  `./setup.rb --module-prs katello/79,capsule/55,gutterball/17,certs/65`

Existing katello needs upgrade and certs update:

```
  foreman-installer --scenario katello --certs-update-all --upgrade
```