### PR TITLE
Bump to 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-katello",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "Katello",
   "summary": "Handles deploying and managing a Katello + Foreman server",
   "license": "GPL-3.0+",


### PR DESCRIPTION
Incompatible changes were made - e.g., param removal of mongod_path.
