### PR TITLE
Don't pass ca cert/key to Pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,9 +86,6 @@ class katello (
   } ~>
   class { '::certs::pulp_parent': } ~>
   class { '::pulp':
-    ca_cert               => $::certs::ca_cert,
-    ca_key                => $::certs::ca_key,
-    ssl_ca_cert           => $::certs::ca_cert,
     oauth_enabled         => true,
     oauth_key             => $katello::oauth_key,
     oauth_secret          => $katello::oauth_secret,


### PR DESCRIPTION
The ca_key and ca_cert options are used by Pulp when creating and
signing consumer certs. Not only do we not use this ability of Pulp
but these options are being deprecated by Pulp.