### PR TITLE
add a truststore_password parameter for candlepin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,7 +76,7 @@ class katello (
     ca_key                       => $certs::ca_key,
     ca_cert                      => $certs::ca_cert_stripped,
     keystore_password            => $::certs::candlepin::keystore_password,
-    truststore_password          => $::certs::candlepin::truststore_password,
+    truststore_password          => $::certs::candlepin::keystore_password,
     enable_basic_auth            => false,
     consumer_system_name_pattern => '.+',
     adapter_module               => 'org.candlepin.katello.KatelloModule',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class katello (
     ca_key                       => $certs::ca_key,
     ca_cert                      => $certs::ca_cert_stripped,
     keystore_password            => $::certs::candlepin::keystore_password,
+    truststore_password          => $::certs::candlepin::truststore_password,
     enable_basic_auth            => false,
     consumer_system_name_pattern => '.+',
     adapter_module               => 'org.candlepin.katello.KatelloModule',


### PR DESCRIPTION
This adds support for truststore password for candlepin, as pushed in PR#32.

I will also open a PR for puppet-certs to add the corresponding parameter