### PR TITLE
Fixes #13189 - allows for certificate authentication of capsules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,7 @@ class katello (
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     ssl_cert_name          => 'broker',
   } ~>
+  class { '::certs::pulp_client': } ~>
   class { '::certs::pulp_parent': } ~>
   class { '::pulp':
     oauth_enabled          => true,

--- a/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
+++ b/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
@@ -3,7 +3,7 @@
 # CHANGES WILL LIKELY BE OVERWRITTEN.
 #
 
-SSLOptions +StdEnvVars +ExportCertData +FakeBasicAuth
+SSLUsername SSL_CLIENT_S_DN_CN
 
 Alias /pub /var/www/html/pub
 <Location /pub>


### PR DESCRIPTION
Requires https://github.com/Katello/puppet-certs/pull/70