### PR TITLE
Fixes #13503 - Updating post sync url

### DIFF
--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -35,7 +35,7 @@ describe 'katello::config' do
       content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
         ':katello:',
         '  :rest_client_timeout: 120',
-        '  :post_sync_url: https://localhost/katello/api/v2/repositories/sync_complete?token=test_token',
+        '  :post_sync_url: https://host.example.org/katello/api/v2/repositories/sync_complete?token=test_token',
         '  :candlepin:',
         '    :url: https://localhost:8443/candlepin',
         '    :oauth_key: katello',
@@ -73,7 +73,7 @@ describe 'katello::config' do
       content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
         ':katello:',
         '  :rest_client_timeout: 120',
-        '  :post_sync_url: https://localhost/katello/api/v2/repositories/sync_complete?token=test_token',
+        '  :post_sync_url: https://host.example.org/katello/api/v2/repositories/sync_complete?token=test_token',
         '  :candlepin:',
         '    :url: https://localhost:8443/candlepin',
         '    :oauth_key: katello',

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -8,7 +8,7 @@
 
   :rest_client_timeout: 120
 
-  :post_sync_url: https://localhost<%= @deployment_url %>/api/v2/repositories/sync_complete?token=<%= @post_sync_token %>
+  :post_sync_url: https://<%= @fqdn %><%= @deployment_url %>/api/v2/repositories/sync_complete?token=<%= @post_sync_token %>
 
   :candlepin:
     :url: <%= @candlepin_url %>


### PR DESCRIPTION
Updating server post sync url to fqdn since it needs to match the cn in
the katello cert and not (localhost)