### PR TITLE
Refs #13658 - remove cycle from puppet graph

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,8 @@ class katello::config {
 
   $apache_version = $::apache::apache_version
 
+  class { '::katello::config::pulp_client': }
+
   file { '/usr/share/foreman/bundler.d/katello.rb':
     ensure => file,
     owner  => $katello::user,
@@ -32,16 +34,5 @@ class katello::config {
     mode   => '0755',
   }
 
-  foreman_config_entry { 'pulp_client_cert':
-    value          => $::certs::pulp_client::client_cert,
-    ignore_missing => false,
-    require        => [Exec['foreman-rake-db:seed'], Class['::certs::pulp_client']],
-  }
-
-  foreman_config_entry { 'pulp_client_key':
-    value          => $::certs::pulp_client::client_key,
-    ignore_missing => false,
-    require        => [Exec['foreman-rake-db:seed'], Class['::certs::pulp_client']],
-  }
 
 }

--- a/manifests/config/pulp_client.pp
+++ b/manifests/config/pulp_client.pp
@@ -1,0 +1,18 @@
+#Katello Pulp Client config
+class katello::config::pulp_client {
+
+  class { '::certs::pulp_client': }
+
+  foreman_config_entry { 'pulp_client_cert':
+    value          => $::certs::pulp_client::client_cert,
+    ignore_missing => false,
+    require        => [Class['::certs::pulp_client'], Exec['foreman-rake-db:seed']],
+  }
+
+  foreman_config_entry { 'pulp_client_key':
+    value          => $::certs::pulp_client::client_key,
+    ignore_missing => false,
+    require        => [Class['::certs::pulp_client'], Exec['foreman-rake-db:seed']],
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,6 @@ class katello (
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     ssl_cert_name          => 'broker',
   } ~>
-  class { '::certs::pulp_client': } ~>
   class { '::certs::pulp_parent': } ~>
   class { '::pulp':
     oauth_enabled          => true,


### PR DESCRIPTION
The previous commit (https://github.com/Katello/puppet-katello/commit/4ecc339d16b88f1a450f075fc14e0c0a103a3e4a) added two cycles to the puppet dep graph, causing `katello-installer` to fail.

The offending line was:

```
require        => [Exec['foreman-rake-db:seed'], Class['::certs::pulp_client']],
```

Note that each of these `require`s individually will cause a cycle. The cycle for just `foreman-rake-db:seed` is http://i.imgur.com/eA8rWc6.png and the cycle for `::certs::pulp_client` is http://i.imgur.com/EgeI2X2.png.

Removal of these lines makes `katello-installer` succeed.