### PR TITLE
Fixes #14324 - Restarts foreman-tasks and httpd on ostree enable

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,7 @@ class katello::install {
   if $katello::enable_ostree {
     package { $katello::rubygem_katello_ostree:
       ensure => installed,
+      notify => Service['foreman-tasks', 'httpd'],
     }
   }
 }

--- a/spec/classes/katello_install_spec.rb
+++ b/spec/classes/katello_install_spec.rb
@@ -33,6 +33,7 @@ describe 'katello::install' do
        }"
       ]
     end
-    it { should contain_package("tfm-rubygem-katello_ostree").with_ensure('installed') }
+    it { should contain_package("tfm-rubygem-katello_ostree").with_ensure('installed').
+                                                              with_notify(["Service[foreman-tasks]", "Service[httpd]"]) }
   end
 end


### PR DESCRIPTION
Enabling ostree functionality requires restart of httpd and foreman-tasks
This code provides that functionality