### PR TITLE
Revert "Simplify variables in katello::qpid"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,8 +139,9 @@ class katello (
     ssl_cert_password_file => $certs::qpid::nss_db_password_file,
   } ~>
   class { '::katello::qpid':
-    client_cert => $certs::qpid::client_cert,
-    client_key  => $certs::qpid::client_key,
+    client_cert  => $certs::qpid::client_cert,
+    client_key   => $certs::qpid::client_key,
+    katello_user => $katello::user,
   } ~>
   Exec['foreman-rake-db:seed']
 

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -1,9 +1,8 @@
-# Katello qpid Config
+# Katello Config
 class katello::qpid (
-  $client_cert,
-  $client_key,
-  $katello_user          = $::katello::user,
-  $candlepin_event_queue = $::katello::candlepin_event_queue,
+  $client_cert            = undef,
+  $client_key             = undef,
+  $katello_user           = $katello::user
 ){
   if $katello_user == undef {
     fail('katello_user not defined')
@@ -11,16 +10,16 @@ class katello::qpid (
     Group['qpidd'] ->
     User<|title == $katello_user|>{groups +> 'qpidd'}
   }
-  exec { 'create katello entitlements queue':
-    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' add queue ${candlepin_event_queue} --durable",
-    unless    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' queues ${candlepin_event_queue}",
+  exec { 'create katello entitlments queue':
+    command   => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' add queue ${katello::params::candlepin_event_queue} --durable",
+    unless    => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${katello::params::candlepin_event_queue}",
     path      => '/usr/bin',
     require   => Service['qpidd'],
     logoutput => true,
   }
-  exec { 'bind katello entitlements queue to qpid exchange messages that deal with entitlements':
-    command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' bind event ${candlepin_event_queue} '*.*'",
-    onlyif    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' queues ${candlepin_event_queue}",
+  exec { 'bind katello entitlments queue to qpid exchange messages that deal with entitlements':
+    command   => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' bind event ${katello::params::candlepin_event_queue} '*.*'",
+    onlyif    => "qpid-config --ssl-certificate ${katello::qpid::client_cert} --ssl-key ${katello::qpid::client_key} -b 'amqps://${::fqdn}:5671' queues ${katello::params::candlepin_event_queue}",
     path      => '/usr/bin',
     require   => Service['qpidd'],
     logoutput => true,


### PR DESCRIPTION
Reverts Katello/puppet-katello#119

This broke the pipeline:

```
21:49 [-beav > ==> centos7-devel:  qpid-config --ssl-certificate /etc/pki/katello/certs/centos7-devel.example.com-qpid-broker.crt --ssl-key                                                                        
               /etc/pki/katello/private/centos7-devel.example.com-qpid-broker.key -b 'amqps://centos7-devel.example.com:5671' bind event  '*.*' returned 1 instead of one of [0] 
```
