### PR TITLE
Refs #14698 - create default directory for repo exports

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,5 +34,20 @@ class katello::config {
     mode   => '0755',
   }
 
+  # NB: we define this here to avoid a dependency cycle. It is not a problem if
+  # this dir exists before the pulp RPMs are installed.
+  file { '/var/lib/pulp':
+    ensure => directory,
+    owner  => 'apache',
+    group  => 'apache',
+    mode   => '0755',
+  }
+
+  file { $katello::repo_export_dir:
+    ensure => directory,
+    owner  => $katello::user,
+    group  => $katello::group,
+    mode   => '0755',
+  }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,8 @@
 #                       on the virtualHost for port 443.
 #                       type: integer
 #
+# $repo_export_dir::    Directory to create for repository exports
+#
 class katello (
 
   $user = $katello::params::user,
@@ -69,9 +71,12 @@ class katello (
   $package_names = $katello::params::package_names,
   $enable_ostree = $katello::params::enable_ostree,
   $max_keep_alive = $katello::params::max_keep_alive,
+
+  $repo_export_dir = $katello::params::repo_export_dir,
   ) inherits katello::params {
   validate_bool($enable_ostree)
   validate_integer($max_keep_alive)
+  validate_absolute_path($repo_export_dir)
 
   Class['certs'] ~>
   class { '::certs::apache': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,6 +48,7 @@ class katello::params {
   $user_groups = 'foreman'
   $config_dir  = '/etc/foreman/plugins'
   $log_dir     = '/var/log/foreman/plugins'
+  $repo_export_dir = '/var/lib/pulp/katello-export'
 
   # OAUTH settings
   $oauth_key = 'katello'


### PR DESCRIPTION
Previously, there was no default location for repository exports. This meant
that users had to "leave" Katello and hop into the command line prior to
creating their first repo export.

This commit creates a `/var/lib/pulp/katello-export` directory as part of the
install. Users may optionally point this elsewhere via installer parameter if
needed.

The `/var/lib/pulp/katello-export` directory was chosen since users already
expect that `/var/lib/pulp` and its child dirs may have large disk space
requirements.