### PR TITLE
Remove 'tomcat' param

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,13 +24,6 @@ class katello::params {
   $rhsm_url = '/rhsm'
   $deployment_url = '/katello'
 
-  if file_exists('/usr/sbin/tomcat') and !file_exists('/usr/sbin/tomcat6') {
-    $tomcat = 'tomcat'
-  }
-  else {
-    $tomcat = 'tomcat6'
-  }
-
   # HTTP Proxy settings (currently used by pulp)
   $proxy_url = undef
   $proxy_port = undef


### PR DESCRIPTION
Tomcat not used and 'file_exists' is master side only. This does not work as expected except when using the masterless installer.