### PR TITLE
fixes #15058 - enable mongo auth

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,10 @@
 #
 # $repo_export_dir::    Directory to create for repository exports
 #
+# $pulp_db_username::   Username for the pulp database
+#
+# $pulp_db_password::   Password for the pulp database
+#
 class katello (
 
   $user = $katello::params::user,
@@ -73,6 +77,9 @@ class katello (
   $max_keep_alive = $katello::params::max_keep_alive,
 
   $repo_export_dir = $katello::params::repo_export_dir,
+
+  $pulp_db_username = $katello::params::pulp_db_username,
+  $pulp_db_password = $katello::params::pulp_db_password,
   ) inherits katello::params {
   validate_bool($enable_ostree)
   validate_integer($max_keep_alive)
@@ -136,6 +143,8 @@ class katello (
     num_workers            => $num_pulp_workers,
     enable_parent_node     => false,
     repo_auth              => false,
+    db_username            => $pulp_db_username,
+    db_password            => $pulp_db_password,
   } ~>
   class { '::qpid::client':
     ssl                    => true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,9 @@ class katello::params {
 
   $num_pulp_workers = min($::processorcount, 8)
 
+  $pulp_db_username = 'pulp'
+  $pulp_db_password = cache_data('foreman_cache_data', 'pulp_db_password', random_password(32))
+
   # cdn ssl settings
   $cdn_ssl_version = undef
 


### PR DESCRIPTION
Companion PR's:
- [ ] https://github.com/Katello/puppet-pulp/pull/146
- [ ] https://github.com/Katello/puppet-capsule/pull/84
- [ ] https://github.com/Katello/puppet-katello_devel/pull/75

Test box:
```
mongoauth:
    box: centos7-katello-nightly
    options: --module-prs katello/126,pulp/146,capsule/84
```