### PR TITLE
Remove unused $rhsm_url variable

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,6 @@ class katello::params {
     }
   }
 
-  $rhsm_url = '/rhsm'
   $deployment_url = '/katello'
 
   # HTTP Proxy settings (currently used by pulp)


### PR DESCRIPTION
Since 069214ae72419faf122ec465265cec969e9b4924 this parameter is unused.