### PR TITLE
Fixes #15170 - Moving timeout to a large enough value

### DIFF
--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -34,7 +34,7 @@ describe 'katello::config' do
       content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
       content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
         ':katello:',
-        '  :rest_client_timeout: 120',
+        '  :rest_client_timeout: 3600',
         '  :post_sync_url: https://host.example.org/katello/api/v2/repositories/sync_complete?token=test_token',
         '  :candlepin:',
         '    :url: https://host.example.org:8443/candlepin',
@@ -72,7 +72,7 @@ describe 'katello::config' do
       content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
       content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
         ':katello:',
-        '  :rest_client_timeout: 120',
+        '  :rest_client_timeout: 3600',
         '  :post_sync_url: https://host.example.org/katello/api/v2/repositories/sync_complete?token=test_token',
         '  :candlepin:',
         '    :url: https://host.example.org:8443/candlepin',

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -6,7 +6,7 @@
   :cdn_ssl_version: <%= @cdn_ssl_version %>
   <%- end -%>
 
-  :rest_client_timeout: 120
+  :rest_client_timeout: 3600
 
   :post_sync_url: https://<%= @fqdn %><%= @deployment_url %>/api/v2/repositories/sync_complete?token=<%= @post_sync_token %>
 


### PR DESCRIPTION
This is necessary because we have various operations in Katello that
are synchronus, especially around our interaction with candlepin and
manifest import that we will often time-out during operation.

We need to keep this timeout value high until the API calls we rely on
are implemented in an async manner.