### PR TITLE
Fixes #15727 - Not receiving candlepin messages

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -17,7 +17,7 @@ class katello::qpid (
     path      => '/usr/bin',
     require   => Service['qpidd'],
     logoutput => true,
-  }
+  } ~>
   exec { 'bind katello entitlements queue to qpid exchange messages that deal with entitlements':
     command   => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' bind event ${candlepin_event_queue} '*.*'",
     onlyif    => "qpid-config --ssl-certificate ${client_cert} --ssl-key ${client_key} -b 'amqps://${::fqdn}:5671' queues ${candlepin_event_queue}",


### PR DESCRIPTION
Messages are not being received from candlepin due to exec
blocks not being executed sequentially. The 2nd exec{} is dependent
on the 1st exec{} being completed successfully.