### PR TITLE
Fixes #15841 - limit pulp puppet wsgi procs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,7 @@ class katello (
     num_workers            => $num_pulp_workers,
     enable_parent_node     => false,
     repo_auth              => true,
+    puppet_wsgi_processes  => 1,
   } ~>
   class { '::qpid::client':
     ssl                    => true,


### PR DESCRIPTION
This is a little used feature and extra wsgi
processes use up more open file handles