### PR TITLE
Wrap `PassengerEnabled` in module check

### DIFF
--- a/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
+++ b/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
@@ -7,9 +7,9 @@ SSLUsername SSL_CLIENT_S_DN_CN
 
 Alias /pub /var/www/html/pub
 <Location /pub>
-  <% if @use_passenger %>
-  PassengerEnabled off
-  <% end %>
+  <IfModule mod_passenger.c>
+    PassengerEnabled off
+  </IfModule>
   Options +FollowSymLinks +Indexes
 </Location>
 

--- a/templates/etc/httpd/conf.d/05-foreman.d/katello.conf.erb
+++ b/templates/etc/httpd/conf.d/05-foreman.d/katello.conf.erb
@@ -6,7 +6,9 @@
 Alias /pub /var/www/html/pub
 
 <Location /pub>
-  PassengerEnabled off 
+  <IfModule mod_passenger.c>
+    PassengerEnabled off
+  </IfModule>
   Options +FollowSymLinks +Indexes
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted
@@ -18,6 +20,8 @@ Alias /pub /var/www/html/pub
 Include /etc/pulp/vhosts80/*.conf
 
 <Location /pulp>
-  PassengerEnabled off
+  <IfModule mod_passenger.c>
+    PassengerEnabled off
+  </IfModule>
   Options +FollowSymLinks +Indexes
 </Location>


### PR DESCRIPTION
Previously, this vhost def was disabling passenger even if passenger was not
installed, causing errors.