### PR TITLE
Fixes #16008 - allow setting puppet_repo_root

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,2 @@
 --fail-on-warnings
---no-80chars-check
 --no-class_inherits_from_params_class-check

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ else
 end
 gem 'rspec-puppet', '~> 2.3'
 gem 'puppetlabs_spec_helper', '>= 0.8.0'
-gem 'puppet-lint', '>= 1'
+gem 'puppet-lint', '>= 2'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-empty_string-check'
 gem 'puppet-lint-spaceship_operator_without_tag-check'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@
 #
 # $proxy_password::     Proxy password for authentication
 #
+# $puppet_repo_root::   Directory to write published puppet modules to
+#
 # $cdn_ssl_version::    SSL version used to communicate with the CDN. Optional. Use SSLv23 or TLSv1
 #
 # $num_pulp_workers::   Number of pulp workers to use
@@ -66,6 +68,7 @@ class katello (
   $proxy_port     = $katello::params::proxy_port,
   $proxy_username = $katello::params::proxy_username,
   $proxy_password = $katello::params::proxy_password,
+  $puppet_repo_root = $katello::params::puppet_repo_root,
   $cdn_ssl_version = $katello::params::cdn_ssl_version,
 
   $package_names = $katello::params::package_names,
@@ -77,6 +80,7 @@ class katello (
   validate_bool($enable_ostree)
   validate_integer($max_keep_alive)
   validate_absolute_path($repo_export_dir)
+  validate_absolute_path($puppet_repo_root)
 
   Class['certs'] ~>
   class { '::certs::apache': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,13 @@ class katello::params {
   $proxy_username = undef
   $proxy_password = undef
 
+  if versioncmp($::puppetversion, '4.0') >= 0  {
+    $puppet_repo_root = '/etc/puppetlabs/code/environments/'
+  }
+  else {
+    $puppet_repo_root = '/etc/puppet/environments/'
+  }
+
   $num_pulp_workers = min($::processorcount, 8)
 
   # cdn ssl settings

--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -26,7 +26,7 @@ describe 'katello::config' do
       it 'should generate correct katello.yaml' do
         should contain_file('/etc/foreman/plugins/katello.yaml')
         content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
-        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+        content.split("\n").reject { |c| c =~ /(^#|^$|^.*puppet_repo_root.*$)/ }.should == [
           ':katello:',
           '  :rest_client_timeout: 3600',
           '  :post_sync_url: https://foo.example.com/katello/api/v2/repositories/sync_complete?token=test_token',
@@ -42,6 +42,7 @@ describe 'katello::config' do
           "    :url: amqp:ssl:#{facts[:fqdn]}:5671",
           '    :subscriptions_queue_address: katello_event_queue'
         ]
+        content.should =~ /^.*:puppet_repo_root: \/etc\/puppet.*$/
       end
     end
 
@@ -64,7 +65,7 @@ describe 'katello::config' do
       it 'should generate correct katello.yaml' do
         should contain_file('/etc/foreman/plugins/katello.yaml')
         content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
-        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+        content.split("\n").reject { |c| c =~ /(^#|^$|^.*puppet_repo_root.*$)/ }.should == [
           ':katello:',
           '  :rest_client_timeout: 3600',
           '  :post_sync_url: https://foo.example.com/katello/api/v2/repositories/sync_complete?token=test_token',
@@ -85,6 +86,7 @@ describe 'katello::config' do
           '    :user: admin',
           '    :password: secret_password'
         ]
+        content.should =~ /^.*:puppet_repo_root: \/etc\/puppet.*$/
       end
     end
   end

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -9,6 +9,8 @@
 
   :post_sync_url: https://<%= scope['katello::fqdn'] %><%= scope['katello::deployment_url'] %>/api/v2/repositories/sync_complete?token=<%= scope['katello::post_sync_token'] %>
 
+  :puppet_repo_root: <%= scope['katello::puppet_repo_root'] %>
+
   :candlepin:
     :url: <%= scope['katello::candlepin_url'] %>
     :oauth_key: <%= scope['katello::oauth_key'] %>


### PR DESCRIPTION
Previously, this setting was not set, which made it default to
`/etc/puppet/environments` in Katello.

This patch adds an explicit setting for `puppet_repo_root`, but
defaults to `/etc/puppet/environments/`. Users can optionally override,
for example to `/etc/puppetlabs/code/environments`.