### PR TITLE
Remove keepalive settings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,10 +43,6 @@
 # $package_names::      Packages that this module ensures are present instead of the default
 #                       type:array
 #
-# $max_keep_alive::     Maximum number of requests to use for the apache MaxKeepAliveRequests parameter
-#                       on the virtualHost for port 443.
-#                       type: integer
-#
 class katello (
 
   $user = $katello::params::user,
@@ -69,12 +65,10 @@ class katello (
 
   $package_names = $katello::params::package_names,
   $enable_ostree = $katello::params::enable_ostree,
-  $max_keep_alive = $katello::params::max_keep_alive,
 
   $repo_export_dir = $katello::params::repo_export_dir,
   ) inherits katello::params {
   validate_bool($enable_ostree)
-  validate_integer($max_keep_alive)
   validate_absolute_path($repo_export_dir)
 
   Class['certs'] ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,5 +60,4 @@ class katello::params {
   $qpid_url = 'amqp:ssl:localhost:5671'
   $candlepin_event_queue = 'katello_event_queue'
   $enable_ostree = false
-  $max_keep_alive = 10000
 }

--- a/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
+++ b/templates/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb
@@ -26,8 +26,3 @@ Alias /pub /var/www/html/pub
   ErrorDocument 500 '{"displayMessage": "Internal error, contact administrator", "errors": ["Internal error, contact administrator"], "status": "500" }'
   ErrorDocument 503 '{"displayMessage": "Service unavailable or restarting, try later", "errors": ["Service unavailable or restarting, try later"], "status": "503" }'
 </LocationMatch>
-
-KeepAlive On
-<% unless [nil, :undefined, :undef, ''].include?(scope['katello::max_keep_alive']) -%>
-MaxKeepAliveRequests <%= scope['::katello::max_keep_alive'] %>
-<% end -%>


### PR DESCRIPTION
https://github.com/theforeman/puppet-foreman/commit/0a6966ce22111b1ce592b5e215a948b3734680e7 introduced these parameters in puppet-foreman so these are duplicate.

It should be noted that puppet-foreman has a very different default (100) from what's removed here (10000). It should also be added in a migration in katello-installer if we decide to do this.