### PR TITLE
Enable crane in Katello too

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,7 @@ class katello (
     manage_httpd           => false,
     manage_plugins_httpd   => true,
     manage_squid           => true,
+    enable_crane           => true,
     enable_rpm             => true,
     enable_puppet          => true,
     enable_docker          => true,


### PR DESCRIPTION
Previously puppet-capsule enabled crane on both capsules and crane,
but this has moved into the pulp config which is currently separate

Needs https://github.com/Katello/puppet-pulp/pull/170