### PR TITLE
Optimize tests

### DIFF
--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -23,8 +23,7 @@ describe 'katello::config' do
 
       it 'should generate correct katello.yaml' do
         should contain_file('/etc/foreman/plugins/katello.yaml')
-        content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
-        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+        verify_exact_contents(catalogue,  '/etc/foreman/plugins/katello.yaml', [
           ':katello:',
           '  :rest_client_timeout: 3600',
           '  :post_sync_url: https://foo.example.com/katello/api/v2/repositories/sync_complete?token=test_token',
@@ -41,7 +40,7 @@ describe 'katello::config' do
           '  :qpid:',
           "    :url: amqp:ssl:localhost:5671",
           '    :subscriptions_queue_address: katello_event_queue'
-        ]
+        ])
       end
     end
 
@@ -63,8 +62,7 @@ describe 'katello::config' do
 
       it 'should generate correct katello.yaml' do
         should contain_file('/etc/foreman/plugins/katello.yaml')
-        content = catalogue.resource('file', '/etc/foreman/plugins/katello.yaml').send(:parameters)[:content]
-        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+        verify_exact_contents(catalogue,  '/etc/foreman/plugins/katello.yaml', [
           ':katello:',
           '  :rest_client_timeout: 3600',
           '  :post_sync_url: https://foo.example.com/katello/api/v2/repositories/sync_complete?token=test_token',
@@ -86,7 +84,7 @@ describe 'katello::config' do
           '    :port: 8888',
           '    :user: admin',
           '    :password: secret_password'
-        ]
+        ])
       end
     end
   end

--- a/spec/classes/katello_config_spec.rb
+++ b/spec/classes/katello_config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'katello::config' do
-  on_supported_os.each do |os, facts|
+  on_os_under_test.each do |os, facts|
     let(:facts) { facts }
 
     context 'default config settings' do

--- a/spec/classes/katello_install_spec.rb
+++ b/spec/classes/katello_install_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'katello::install' do
-  on_supported_os.each do |os, facts|
+  on_os_under_test.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
 

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'katello' do
-  on_supported_os.each do |os, facts|
+  on_os_under_test.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
 


### PR DESCRIPTION
By using on_supported_os we can benefit from ONLY_OS thus reducing our test runtime. The use of verify_exact_contents makes it slightly easier to read.