### PR TITLE
fixes errata - Exec foreman-rake-db:seed and foreman-rake-db:migrate …

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,12 @@ class katello::config {
 
   $apache_version = $::apache::apache_version
 
+  exec { 'foreman-rake-db:migrate':
+    command     => 'foreman-rake db:migrate',
+    path        => '/bin:/sbin:/usr/bin:/usr/sbin:',
+    refreshonly => true,
+  }
+
   class { '::katello::config::pulp_client': }
 
   file { '/usr/share/foreman/bundler.d/katello.rb':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,12 @@ class katello (
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::ca_cert
 
+  exec { 'foreman-rake-db:seed':
+    command     => 'foreman-rake db:seed',
+    path        => '/bin:/sbin:/usr/bin:/usr/sbin:',
+    refreshonly => true,
+  }
+
   Class['certs'] ~>
   class { '::certs::apache': } ~>
   class { '::katello::install': } ~>


### PR DESCRIPTION
…resources were not defined

If I run foreman-installer with some foreman-db-* options, it fails.
the command I tried was:
```
foreman-installer --scenario katello \
  --certs-city Seoul \
  --certs-country KR \
  --certs-org-unit SystemTeam \
  --certs-state Seoul \
  --foreman-admin-password ***** \
  --foreman-db-manage false \
  --foreman-db-host 172.16.0.187 \
  --foreman-db-database db_katello \
  --foreman-db-username katello \
  --foreman-db-password ******
```

so I tried what makes an these kind error and found that the class katello calls some resources which are not defined such as foreman-rake-db:seed and foreman-rake-db:migrate.
when I add these in the init file, run successfully.