### PR TITLE
Preparations to seperate logic out of the certs module

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,5 +63,6 @@ class katello::params {
 
   $qpid_url = 'amqp:ssl:localhost:5671'
   $candlepin_event_queue = 'katello_event_queue'
+  $candlepin_qpid_exchange = 'event'
   $enable_ostree = false
 }


### PR DESCRIPTION
the qpid exchange creation should not be part of the puppet-certs module

additional change to make the host it uses for the qpid connection as parameter, defaults to localhost

someone with some more qpid insight should determine if that exchange is actually needed and used please :)