### PR TITLE
pulp: enable katello

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,7 @@ class katello (
     repo_auth              => true,
     puppet_wsgi_processes  => 1,
     crane_data_dir         => '/var/lib/pulp/published/docker/v2/app',
+    enable_katello         => true,
   } ~>
   class { '::qpid::client':
     ssl                    => true,


### PR DESCRIPTION
pulp should have katello enabled so that the package `pulp-katello` is installed. On a all-in-one install this happens because the katello package depends on pulp-katello.
https://github.com/Katello/katello-packaging/blob/master/katello/katello.spec#L40