### PR TITLE
Split apache fragments

### DIFF
--- a/files/katello-apache-ssl.conf
+++ b/files/katello-apache-ssl.conf
@@ -1,17 +1,3 @@
-### File managed with puppet ###
-
-<Location /pulp/api>
-  SSLUsername SSL_CLIENT_S_DN_CN
-</Location>
-
-Alias /pub /var/www/html/pub
-<Location /pub>
-  <IfModule mod_passenger.c>
-    PassengerEnabled off
-  </IfModule>
-  Options +FollowSymLinks +Indexes
-</Location>
-
 <LocationMatch /rhsm|/katello/api>
   # if ssl_client_certa is present set the header, otherwise don't override
   # a reverse proxy may already be sending the cert through this header

--- a/files/pulp-apache-ssl.conf
+++ b/files/pulp-apache-ssl.conf
@@ -1,0 +1,13 @@
+### File managed with puppet ###
+
+<Location /pulp/api>
+  SSLUsername SSL_CLIENT_S_DN_CN
+</Location>
+
+Alias /pub /var/www/html/pub
+<Location /pub>
+  <IfModule mod_passenger.c>
+    PassengerEnabled off
+  </IfModule>
+  Options +FollowSymLinks +Indexes
+</Location>

--- a/files/pulp-apache.conf
+++ b/files/pulp-apache.conf
@@ -7,11 +7,7 @@ Alias /pub /var/www/html/pub
     PassengerEnabled off
   </IfModule>
   Options +FollowSymLinks +Indexes
-<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted
-<% else -%>
-  Allow from all
-<% end -%>
 </Location>
 
 Include /etc/pulp/vhosts80/*.conf

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,8 +1,6 @@
 # Katello Config
 class katello::config {
 
-  $apache_version = $::apache::apache_version
-
   class { '::katello::config::pulp_client': }
 
   file { '/usr/share/foreman/bundler.d/katello.rb':
@@ -23,8 +21,12 @@ class katello::config {
   }
 
   foreman::config::passenger::fragment{ 'katello':
-    content     => template('katello/etc/httpd/conf.d/05-foreman.d/katello.conf.erb'),
-    ssl_content => template('katello/etc/httpd/conf.d/05-foreman-ssl.d/katello.conf.erb'),
+    ssl_content => file('katello/katello-apache-ssl.conf'),
+  }
+
+  foreman::config::passenger::fragment{ 'pulp':
+    content     => file('katello/pulp-apache.conf'),
+    ssl_content => file('katello/pulp-apache-ssl.conf'),
   }
 
   # NB: we define this here to avoid a dependency cycle. It is not a problem if


### PR DESCRIPTION
This patch drops support for Apache 2.2, but we only support EL7 which
ships 2.4.

It is untested, but I need this to easily test it in a pipeline run.