### PR TITLE
Fixes #19667 - expose Candlepin DB setup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,8 @@
 #
 # $candlepin_db_ssl_verify:: Boolean indicating if the SSL connection to the database should be verified
 #
+# $candlepin_manage_db:: Boolean indicating whether a database should be installed, this includes db creation and user
+#
 class katello (
   String $user = $::katello::params::user,
   String $group = $::katello::params::group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,16 @@
 #
 # $repo_gpgkey::        The GPG key to use
 #
+# $candlepin_db_host::  Host with Candlepin DB
+#
+# $candlepin_db_port::  Port accepting connections to Candlepin DB
+#
+# $candlepin_db_name::  Name of the Candlepin DB
+#
+# $candlepin_db_user::  Candlepin DB user
+#
+# $candlepin_db_password:: Candlepin DB password
+#
 class katello (
   String $user = $::katello::params::user,
   String $group = $::katello::params::group,
@@ -83,6 +93,12 @@ class katello (
   String $repo_version = $::katello::params::repo_version,
   Boolean $repo_gpgcheck = $::katello::params::repo_gpgcheck,
   Optional[String] $repo_gpgkey = $::katello::params::repo_gpgkey,
+
+  String $candlepin_db_host = $::katello::params::candlepin_db_host,
+  Optional[String] $candlepin_db_port = $::katello::params::candlepin_db_port,
+  String $candlepin_db_name = $::katello::params::candlepin_db_name,
+  String $candlepin_db_user = $::katello::params::candlepin_db_user,
+  String $candlepin_db_password = $::katello::params::candlepin_db_password,
 ) inherits katello::params {
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::katello_server_ca_cert
@@ -120,6 +136,11 @@ class katello (
     amqp_truststore              => $::certs::candlepin::amqp_truststore,
     qpid_ssl_cert                => $::certs::qpid::client_cert,
     qpid_ssl_key                 => $::certs::qpid::client_key,
+    db_host                      => $katello::candlepin_db_host,
+    db_port                      => $katello::candlepin_db_port,
+    db_name                      => $katello::candlepin_db_name,
+    db_user                      => $katello::candlepin_db_user,
+    db_password                  => $katello::candlepin_db_password,
   } ~>
   class { '::certs::qpid_client': } ~>
   class { '::pulp':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class katello (
   String $candlepin_db_password = $::katello::params::candlepin_db_password,
   Boolean $candlepin_db_ssl = $::katello::params::candlepin_db_ssl,
   Boolean $candlepin_db_ssl_verify = $::katello::params::candlepin_db_ssl_verify,
+  Boolean $candlepin_manage_db = $::katello::params::candlepin_manage_db,
 ) inherits katello::params {
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::katello_server_ca_cert
@@ -150,6 +151,7 @@ class katello (
     db_password                  => $candlepin_db_password,
     db_ssl                       => $candlepin_db_ssl,
     db_ssl_verify                => $candlepin_db_ssl_verify,
+    manage_db                    => $candlepin_manage_db,
   } ~>
   class { '::certs::qpid_client': } ~>
   class { '::pulp':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@ class katello (
   Optional[String] $repo_gpgkey = $::katello::params::repo_gpgkey,
 
   String $candlepin_db_host = $::katello::params::candlepin_db_host,
-  Optional[String] $candlepin_db_port = $::katello::params::candlepin_db_port,
+  Optional[Integer[0, 65535]] $candlepin_db_port = $::katello::params::candlepin_db_port,
   String $candlepin_db_name = $::katello::params::candlepin_db_name,
   String $candlepin_db_user = $::katello::params::candlepin_db_user,
   String $candlepin_db_password = $::katello::params::candlepin_db_password,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,11 @@
 #
 # $candlepin_db_password:: Candlepin DB password
 #
+# $candlepin_db_ssl::   Boolean indicating if the connection to the database should be over
+#                       an SSL connection.
+#
+# $candlepin_db_ssl_verify:: Boolean indicating if the SSL connection to the database should be verified
+#
 class katello (
   String $user = $::katello::params::user,
   String $group = $::katello::params::group,
@@ -99,6 +104,8 @@ class katello (
   String $candlepin_db_name = $::katello::params::candlepin_db_name,
   String $candlepin_db_user = $::katello::params::candlepin_db_user,
   String $candlepin_db_password = $::katello::params::candlepin_db_password,
+  Boolean $candlepin_db_ssl = $::katello::params::candlepin_db_ssl,
+  Boolean $candlepin_db_ssl_verify = $::katello::params::candlepin_db_ssl_verify,
 ) inherits katello::params {
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::katello_server_ca_cert
@@ -141,6 +148,8 @@ class katello (
     db_name                      => $candlepin_db_name,
     db_user                      => $candlepin_db_user,
     db_password                  => $candlepin_db_password,
+    db_ssl                       => $candlepin_db_ssl,
+    db_ssl_verify                => $candlepin_db_ssl_verify,
   } ~>
   class { '::certs::qpid_client': } ~>
   class { '::pulp':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@
 # $candlepin_db_password:: Candlepin DB password
 #
 # $candlepin_db_ssl::   Boolean indicating if the connection to the database should be over
-#                       an SSL connection.
+#                       an SSL connection. Requires DB host's CA Cert in the system trust
 #
 # $candlepin_db_ssl_verify:: Boolean indicating if the SSL connection to the database should be verified
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,11 +136,11 @@ class katello (
     amqp_truststore              => $::certs::candlepin::amqp_truststore,
     qpid_ssl_cert                => $::certs::qpid::client_cert,
     qpid_ssl_key                 => $::certs::qpid::client_key,
-    db_host                      => $katello::candlepin_db_host,
-    db_port                      => $katello::candlepin_db_port,
-    db_name                      => $katello::candlepin_db_name,
-    db_user                      => $katello::candlepin_db_user,
-    db_password                  => $katello::candlepin_db_password,
+    db_host                      => $candlepin_db_host,
+    db_port                      => $candlepin_db_port,
+    db_name                      => $candlepin_db_name,
+    db_user                      => $candlepin_db_user,
+    db_password                  => $candlepin_db_password,
   } ~>
   class { '::certs::qpid_client': } ~>
   class { '::pulp':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,4 +70,11 @@ class katello::params {
   $repo_yumcode = "el${::operatingsystemmajrelease}"
   $repo_gpgcheck = false
   $repo_gpgkey = undef
+
+  # candlepin database settings
+  $candlepin_db_host = 'localhost'
+  $candlepin_db_port = undef
+  $candlepin_db_name = 'candlepin'
+  $candlepin_db_user = 'candlepin'
+  $candlepin_db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,4 +77,6 @@ class katello::params {
   $candlepin_db_name = 'candlepin'
   $candlepin_db_user = 'candlepin'
   $candlepin_db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))
+  $candlepin_db_ssl = false
+  $candlepin_db_ssl_verify = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,4 +79,5 @@ class katello::params {
   $candlepin_db_password = cache_data('foreman_cache_data', 'candlepin_db_password', random_password(32))
   $candlepin_db_ssl = false
   $candlepin_db_ssl_verify = true
+  $candlepin_manage_db = true
 }


### PR DESCRIPTION
Exposing Candlpin DB parameters via katello module allows users to
customize the DB setup using installer parameters.

Current default Candlepin DB setup remains unaffected. Using external
Postgress with prepared DB is possible.

I've tested the default Katello install and also fresh installation with remote DB using:
```
foreman-installer --scenario katello --foreman-admin-password changeme --foreman-db-host X.X.X.X --foreman-db-password foreman --foreman-db-database foreman --katello-candlepin-db-host X.X.X.X - -katello-candlepin-db-name candlepin --katello-candlepin-db-password candlepin
``` 
The remote DB use-case assumes 
 - the DB server allows connection from the Katello server 
 - has one database for Foreman and one for Candlepin
 - postgress users owning the databases can auth in using md5
