### PR TITLE
fixes #20353 - Runs apipie cache after ostree

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@ class katello::install {
   if $katello::enable_ostree {
     package { $katello::rubygem_katello_ostree:
       ensure => installed,
-      notify => Service['foreman-tasks', 'httpd'],
+      notify => [Service['foreman-tasks', 'httpd'], Exec['foreman-rake-apipie:cache:index']],
     }
   }
 }

--- a/spec/classes/katello_install_spec.rb
+++ b/spec/classes/katello_install_spec.rb
@@ -28,7 +28,7 @@ describe 'katello::install' do
           ]
         end
         it { should contain_package("tfm-rubygem-katello_ostree").with_ensure('installed').
-                                                                  with_notify(["Service[foreman-tasks]", "Service[httpd]"]) }
+                                                                  with_notify(["Service[foreman-tasks]", "Service[httpd]", "Exec[foreman-rake-apipie:cache:index]"]) }
       end
     end
   end


### PR DESCRIPTION
We need to run ```/usr/sbin/foreman-rake apipie:cache:index ``` after installing ostree. So added that option in the installer and closing https://github.com/Katello/katello-packaging/pull/483