### PR TITLE
Fixes #20518 - set pulp tasks to 2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class katello::params {
   $proxy_password = undef
 
   $num_pulp_workers = min($::processorcount, 8)
-  $max_tasks_per_pulp_worker = undef
+  $max_tasks_per_pulp_worker = 2
 
   # Pulp max speed setting
   $pulp_max_speed = undef


### PR DESCRIPTION
Downstream this change was made for performance reasons, reference in the following BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1388631