### PR TITLE
Ensure the candlepin keystore symlink

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -51,4 +51,13 @@ class katello::candlepin (
   }
 
   contain ::candlepin
+
+  file { '/etc/tomcat/keystore':
+    ensure  => link,
+    target  => $::certs::candlepin::keystore,
+    owner   => 'tomcat',
+    group   => $::certs::group,
+    require => Class['candlepin::install', 'certs::candlepin'],
+    notify  => Class['candlepin::service'],
+  }
 }


### PR DESCRIPTION
This was previously in puppet-certs as /usr/share/tomcat/conf/keystore
but it doesn't belong there. Because /usr/share/tomcat/conf is a symlink
to /etc/tomcat we can safely manage it here as well without duplicating
resources.