### PR TITLE
candlepin: use own certs for qpid

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -22,6 +22,8 @@ class katello::application (
   include ::certs::apache
   include ::certs::foreman
   include ::certs::pulp_client
+  include ::certs::qpid
+  include ::katello::qpid_client
 
   $post_sync_url = "${::foreman::foreman_url}${deployment_url}/api/v2/repositories/sync_complete?token=${post_sync_token}"
   $candlepin_ca_cert = $::certs::ca_cert
@@ -50,6 +52,7 @@ class katello::application (
   include ::foreman::plugin::tasks
 
   Class['certs', 'certs::ca', 'certs::apache'] ~> Class['apache::service']
+  Class['certs', 'certs::ca', 'certs::qpid'] ~> Class['foreman::plugin::tasks']
 
   # Katello database seeding needs candlepin
   package { $package_names:

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -14,9 +14,7 @@ class katello::candlepin (
   String $qpid_hostname = $::katello::qpid_hostname,
 ) {
   include ::certs
-  include ::certs::qpid
   include ::certs::candlepin
-  include ::katello::qpid_client
 
   class { '::candlepin':
     user_groups                  => $user_groups,
@@ -35,8 +33,8 @@ class katello::candlepin (
     amqp_keystore                => $::certs::candlepin::amqp_keystore,
     amqp_truststore              => $::certs::candlepin::amqp_truststore,
     qpid_hostname                => $qpid_hostname,
-    qpid_ssl_cert                => $::certs::qpid::client_cert,
-    qpid_ssl_key                 => $::certs::qpid::client_key,
+    qpid_ssl_cert                => $::certs::candlepin::client_cert,
+    qpid_ssl_key                 => $::certs::candlepin::client_key,
     db_host                      => $db_host,
     db_port                      => $db_port,
     db_name                      => $db_name,
@@ -45,7 +43,7 @@ class katello::candlepin (
     db_ssl                       => $db_ssl,
     db_ssl_verify                => $db_ssl_verify,
     manage_db                    => $manage_db,
-    subscribe                    => Class['certs', 'certs::qpid', 'certs::candlepin'],
+    subscribe                    => Class['certs', 'certs::candlepin'],
   }
 
   contain ::candlepin

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -1,4 +1,6 @@
-# Install and configure a qpid client
+# Install and configure a qpid client.
+# This is used by the Katello rails app to connect to the
+# qpid message broker.
 class katello::qpid_client {
   include ::certs
   include ::certs::qpid

--- a/spec/classes/katello_application_spec.rb
+++ b/spec/classes/katello_application_spec.rb
@@ -34,6 +34,8 @@ describe 'katello::application' do
           it { is_expected.not_to contain_package('tfm-rubygem-katello_ostree') }
           it { is_expected.to create_package('tfm-rubygem-katello') }
           it { is_expected.to create_file('/usr/share/foreman/bundler.d/katello.rb') }
+          it { is_expected.to contain_class('certs::qpid') }
+          it { is_expected.to contain_class('katello::qpid_client') }
 
           it do
             is_expected.to create_foreman_config_entry('pulp_client_cert')
@@ -61,6 +63,11 @@ describe 'katello::application' do
             is_expected.to create_foreman__config__passenger__fragment('katello')
               .without_content()
               .with_ssl_content(%r{^<LocationMatch /rhsm\|/katello/api>$})
+          end
+
+          it do
+            is_expected.to contain_class('certs::qpid')
+              .that_notifies(['Class[Foreman::Plugin::Tasks]'])
           end
 
           it 'should generate correct katello.yaml' do

--- a/spec/classes/katello_candlepin_spec.rb
+++ b/spec/classes/katello_candlepin_spec.rb
@@ -24,9 +24,7 @@ describe 'katello::candlepin' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('certs::qpid') }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('katello::qpid_client') }
         it { is_expected.to contain_class('candlepin') }
       end
 
@@ -36,9 +34,7 @@ describe 'katello::candlepin' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('certs::qpid') }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('katello::qpid_client') }
         it { is_expected.to contain_class('candlepin') }
       end
     end


### PR DESCRIPTION
The `qpid_ssl_cert` and `qpid_ssl_key` parameters for `candlepin` are just to [set up an exchange](https://github.com/Katello/puppet-candlepin/blob/bdcfccd827e2f8f5477e37a1f20923641fb4439a/manifests/qpid.pp#L7-L10).

This can be done with candlepin's qpid certificates and removed the dependency for qpid's certificates.