### PR TITLE
qpidd: hostname for config cmds

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,10 @@
 #
 # $qpid_wcache_page_size:: The size (in KB) of the pages in the write page cache
 #
+# $qpid_interface::     The interface qpidd listens to.
+#
+# $qpid_hostname::      Hostname used to connect to qpidd.
+#
 # $package_names::      Packages that this module ensures are present instead of the default
 #
 # $manage_repo::        Whether to manage the yum repository
@@ -79,6 +83,8 @@ class katello (
 
   String $post_sync_token = $::katello::params::post_sync_token,
   Integer[0, 1000] $qpid_wcache_page_size = $::katello::params::qpid_wcache_page_size,
+  String $qpid_interface = $::katello::params::qpid_interface,
+  String $qpid_hostname = $::katello::params::qpid_hostname,
   Integer[1] $num_pulp_workers = $::katello::params::num_pulp_workers,
   Optional[Integer] $max_tasks_per_pulp_worker = $::katello::params::max_tasks_per_pulp_worker,
   Optional[Stdlib::HTTPUrl] $proxy_url = $::katello::params::proxy_url,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,7 @@ class katello::params {
   $reset_data = 'NONE'
 
   $qpid_hostname = 'localhost'
+  $qpid_interface = 'lo'
   $qpid_url = "amqp:ssl:${qpid_hostname}:5671"
   $candlepin_event_queue = 'katello_event_queue'
   $candlepin_qpid_exchange = 'event'

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -4,7 +4,8 @@ class katello::qpid (
   String $candlepin_event_queue = $::katello::candlepin_event_queue,
   String $candlepin_qpid_exchange = $::katello::candlepin_qpid_exchange,
   Integer[0, 5000] $wcache_page_size = $::katello::qpid_wcache_page_size,
-  String $interface = 'lo',
+  String $interface = $::katello::qpid_interface,
+  String $hostname = $::katello::qpid_hostname,
 ) {
   include ::certs
   include ::certs::qpid
@@ -28,10 +29,12 @@ class katello::qpid (
     onlyif   => "list binding | grep ${candlepin_event_queue} | grep '*.*'",
     ssl_cert => $::certs::qpid::client_cert,
     ssl_key  => $::certs::qpid::client_key,
+    hostname => $hostname,
   } ->
   qpid::config::queue { $candlepin_event_queue:
     ssl_cert => $::certs::qpid::client_cert,
     ssl_key  => $::certs::qpid::client_key,
+    hostname => $hostname,
   }
 
   qpid::config::bind { ['entitlement.created', 'entitlement.deleted', 'pool.created', 'pool.deleted', 'compliance.created']:
@@ -39,5 +42,6 @@ class katello::qpid (
     exchange => $candlepin_qpid_exchange,
     ssl_cert => $::certs::qpid::client_cert,
     ssl_key  => $::certs::qpid::client_key,
+    hostname => $hostname,
   }
 }

--- a/spec/classes/katello_qpid_spec.rb
+++ b/spec/classes/katello_qpid_spec.rb
@@ -15,6 +15,7 @@ describe 'katello::qpid' do
             :candlepin_qpid_exchange => 'event',
             :wcache_page_size        => 8,
             :interface               => 'eth0',
+            :hostname                => 'localhost',
           }
         end
 


### PR DESCRIPTION
This PR allows configuring the hostname that is used to connect to `qpidd` while setting up queues etc. This is necessary when a developer sets `interface` to something else than `lo`.