### PR TITLE
pulp: remove candlepin consumers crl

### DIFF
--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -18,8 +18,6 @@ class katello::pulp (
 ) {
   include ::certs
   include ::certs::qpid_client
-  # Because we re-use the CRL file
-  include ::katello::candlepin
 
   class { '::pulp':
     oauth_enabled          => true,
@@ -32,7 +30,6 @@ class katello::pulp (
     messaging_auth_enabled => false,
     broker_url             => $broker_url,
     broker_use_ssl         => true,
-    consumers_crl          => $::candlepin::crl_file,
     proxy_url              => $proxy_url,
     proxy_port             => $proxy_port,
     proxy_username         => $proxy_username,

--- a/spec/classes/katello_pulp_spec.rb
+++ b/spec/classes/katello_pulp_spec.rb
@@ -20,7 +20,6 @@ describe 'katello::pulp' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs') }
         it { is_expected.to contain_class('certs::qpid_client') }
-        it { is_expected.to contain_class('katello::candlepin') }
 
         it do
           is_expected.to create_class('pulp')
@@ -34,7 +33,6 @@ describe 'katello::pulp' do
             .with_messaging_auth_enabled(false)
             .with_broker_url('qpid://localhost:5671')
             .with_broker_use_ssl(true)
-            .with_consumers_crl('/var/lib/candlepin/candlepin-crl.crl')
             .with_proxy_url(nil)
             .with_proxy_port(nil)
             .with_proxy_username(nil)


### PR DESCRIPTION
This PR removes the dependency for candlepin from pulp.

This has never worked in the past. We need to properly design this and should implement a working solution.

https://github.com/Katello/puppet-pulp/blob/3bf701bacc8d98cdb49ac37d301322fbce941163/manifests/config.pp#L118-L124

The `refreshonly => true` requies the exec to be notified before it runs. It's never notified.